### PR TITLE
Modify ref function

### DIFF
--- a/js.typ
+++ b/js.typ
@@ -222,10 +222,8 @@
       if book {
         if el.depth == 1 {
           link(el.location(), [第#sec-cnt.at(0)章])
-        } else if el.depth == 2{
-          link(el.location(), [第#sec-cnt.at(0)章#sec-cnt.at(1)節])
         } else {
-          link(el.location(), [第#sec-cnt.at(0)章#sec-cnt.at(1)節#sec-cnt.at(2)項])
+          link(el.location(), [第#sec-cnt.at(0)章#sec-cnt.slice(1).map(n => str(n)).join(".")節])
         }
       }
       else {

--- a/js.typ
+++ b/js.typ
@@ -224,7 +224,7 @@
           link(el.location(), [第#sec-cnt.at(0)章])
         } else if el.depth == 2{
           link(el.location(), [第#sec-cnt.at(0)章#sec-cnt.at(1)節])
-        } else if el.depth == 3{
+        } else {
           link(el.location(), [第#sec-cnt.at(0)章#sec-cnt.at(1)節#sec-cnt.at(2)項])
         }
       }

--- a/js.typ
+++ b/js.typ
@@ -206,7 +206,36 @@
   show table: set text(top-edge: (2 * cjkheight - 1) * fontsize)
   set footnote.entry(indent: 1.6em)
   show figure.where(kind: table): set figure.caption(position: top)
-  set ref(supplement: none)
+  show ref: it => {
+    let eq = math.equation
+    let el = it.element
+    if el != none and el.func() == eq {
+      if eq.numbering != none {
+        link(el.location(), numbering(
+          el.numbering,
+          ..counter(eq).at(el.location())
+        ))
+      }
+    }
+    else if el != none and el.func() == heading {
+      let sec-cnt = counter(heading).at(el.location())
+      if book {
+        if el.depth == 1 {
+          link(el.location(), [第#sec-cnt.at(0)章])
+        } else if el.depth == 2{
+          link(el.location(), [第#sec-cnt.at(0)章#sec-cnt.at(1)節])
+        } else if el.depth == 3{
+          link(el.location(), [第#sec-cnt.at(0)章#sec-cnt.at(1)節#sec-cnt.at(2)項])
+        }
+      }
+      else {
+        link(el.location(), sec-cnt.map(n => str(n)).join("."))
+      }
+    } 
+    else {
+      it
+    }
+  }
   // finally
   body
 }


### PR DESCRIPTION
#3 の対応案です。

> 実はまだそのあたりの仕様については迷っているところです。

とのことでしたが、実際やってみるとわかることもあるかと思い、私の方でも少し考えてみました。
コード的にも色々細かい工夫が必要であったため、プルリクエストの形でご提案させていただきます。
もちろん仕様が固まれば変更していただいて構いません。これが完璧でないにしろ、たたき台となれれば幸いです。

このコードの仕様は以下のとおりです。

- 数式の参照は`#set math.equation(numbering: `の指定に従います。
    - typst-jsテンプレートのデフォルトではnumberingはnoneになっています。その場合にエラーにならないようにif文処理を噛ませてあります。
- 見出しの参照は文書の種類とレベルに応じて変化します。
    - デフォルトではbookがfalseであり、その場合には「2.2.1」など数字のみの記載となります。articleのときに見出し（セクション）を章と扱うか節と扱うか文書によって異なるかと思い、このような対応としています。
    - bookがtrueであるときには「第2章2.1節」のような記載としました。https://github.com/okumuralab/typst-js/issues/3#issuecomment-2848878678 で示したサンプルのように「第2章2節1項」などとすることも考えましたが、レベル4以降の対応を「第2章2節1小節1小小節」などとすると非常に長くなってしまうため、この形式としました。
    - より上位の「部」という単位もあるかと思いますが、これは改ページなどをして独立して作られることが想定されましたため、見出しには含まないという考えです。
- 図、表など上記以外の参照はsupplementによる表示通りです。#3 に応えられていると思います。

動作テスト用のコードとして、以下のsample.typをコンパイルした結果は[sample.pdf](https://github.com/user-attachments/files/20028383/sample.pdf)です。

```sample.typ
#import "js.typ": *
#show: js.with(lang: "ja")

#outline() #v(1em)

= 数式 <somechapter>

#set math.equation(numbering: "(1)")

$ (integral_0^oo (sin x) / sqrt(x) d x)^2
  &= product_(k = 1)^oo (4 k^2) / (4 k^2 - 1) = pi / 2 $
<someequation>

= 図表

== 図 <somesection>

#figure(
  caption: "some figure caption",
  rect[Hello],
) <somefigure>

== 表

#figure(
  caption: "some table caption",
  table(
    columns: 2,
    [*Amount*], [*Ingredient*],
    [360g], [Baking flour],
    [250g], [Butter (room temp.)],
  )
) <sometable>

=== 参照 <somesubsection>

図は@somefigure のように参照されます。

表は@sometable のように参照されます。

数式は@someequation のように参照されます。

見出し1は@somechapter のように参照されます。

見出し2は@somesection のように参照されます。

見出し3は@somesubsection のように参照されます。


#show: js.with(lang: "ja", book: true)

bookをtrueとしたときは以下の通りです。

見出し1は@somechapter のように参照されます。

見出し2は@somesection のように参照されます。

見出し3は@somesubsection のように参照されます。
```

以上、ご参考になれば幸いです。